### PR TITLE
feat: add a ZxcvbnPasswordStrength constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 [![Packagist](https://img.shields.io/packagist/dt/createnl/zxcvbn-bundle)](https://packagist.org/packages/createnl/zxcvbn-bundle)
 
 # Zxcvbn Symfony Bundle
-A bundle to integrate [zxcvbn-php](https://github.com/bjeavons/zxcvbn-php) with your symfony app. Supports localization and custom matchers. 
+A bundle to integrate [zxcvbn-php](https://github.com/bjeavons/zxcvbn-php) with your symfony app. Supports localization and custom matchers.
+This bundle also provides a constraint to validate the strength of a password in a property.
 
 ## Installation
 ```bash
@@ -37,6 +38,22 @@ class PasswordController
     }
 }
 ```
+
+## Validator
+To validate the strength of a password in a property, follow this example:
+
+```php
+use Createnl\ZxcvbnBundle\Validator\Constraints as Assert;
+
+class User
+{
+    #[Assert\ZxcvbnPasswordStrength]
+    private string $password;
+}
+```
+
+You can also use the constraint as an annotation.
+The constraint can take a `minScore` parameter (`4` by default).
 
 ## Localization
 This package supports the localization of warning and suggestion messages. Checks on common passwords, words and (family) names are only in English (US). But you can [tag your own matcher](#extending-matchers) to extend to your needs. 

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
     "require-dev": {
         "symfony/framework-bundle": "^5.4|^6.0",
         "symfony/console": "^5.4|^6.0",
+        "symfony/validator": "^5.4|^6.0",
         "phpunit/phpunit": "^9.5"
     }
 }

--- a/src/DependencyInjection/ZxcvbnBundleExtension.php
+++ b/src/DependencyInjection/ZxcvbnBundleExtension.php
@@ -6,6 +6,7 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use Symfony\Component\Validator\Validation;
 
 class ZxcvbnBundleExtension extends Extension
 {
@@ -17,5 +18,9 @@ class ZxcvbnBundleExtension extends Extension
         );
 
         $loader->load('services.yaml');
+
+        if (class_exists(Validation::class)) {
+            $loader->load('validator.yaml');
+        }
     }
 }

--- a/src/Resources/config/validator.yaml
+++ b/src/Resources/config/validator.yaml
@@ -1,0 +1,6 @@
+services:
+  Createnl\ZxcvbnBundle\Validator\Constraints\ZxcvbnPasswordStrengthValidator:
+    arguments:
+      - '@Createnl\ZxcvbnBundle\ZxcvbnFactory'
+    tags:
+      - 'validator.constraint_validator'

--- a/src/Validator/Constraints/ZxcvbnPasswordStrength.php
+++ b/src/Validator/Constraints/ZxcvbnPasswordStrength.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+namespace Createnl\ZxcvbnBundle\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Exception\InvalidArgumentException;
+
+/**
+ * @Annotation
+ * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
+ */
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+final class ZxcvbnPasswordStrength extends Constraint
+{
+    public const ZXCVBN_PASSWORD_STRENGTH_ERROR = '2d00ebc4-f658-48b2-bebf-269daf0b5e8f';
+
+    protected static $errorNames = [self::ZXCVBN_PASSWORD_STRENGTH_ERROR => 'ZXCVBN_PASSWORD_STRENGTH_ERROR'];
+
+    public string $message = 'This password does not have enough strength.{{ warning }}{{ suggestions }}';
+
+    public int $minScore = 4;
+
+    public function __construct(
+        array $options = null,
+        string $message = null,
+        int $minScore = null,
+        array $groups = null,
+        $payload = null
+    ) {
+        parent::__construct($options, $groups, $payload);
+
+        $this->message = $message ?? $this->message;
+        if ($minScore < 0 || $minScore > 4) {
+            throw new InvalidArgumentException('The "minScore" parameter value is not valid. It should be between 0 and 4.');
+        }
+        $this->minScore = $minScore ?? $this->minScore;
+    }
+}

--- a/src/Validator/Constraints/ZxcvbnPasswordStrengthValidator.php
+++ b/src/Validator/Constraints/ZxcvbnPasswordStrengthValidator.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Createnl\ZxcvbnBundle\Validator\Constraints;
+
+use Createnl\ZxcvbnBundle\ZxcvbnFactoryInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
+
+final class ZxcvbnPasswordStrengthValidator extends ConstraintValidator
+{
+    private ZxcvbnFactoryInterface $zxcvbnFactory;
+
+    public function __construct(ZxcvbnFactoryInterface $zxcvbnFactory)
+    {
+        $this->zxcvbnFactory = $zxcvbnFactory;
+    }
+
+    public function validate($value, Constraint $constraint)
+    {
+        if (!$constraint instanceof ZxcvbnPasswordStrength) {
+            throw new UnexpectedTypeException($constraint, ZxcvbnPasswordStrength::class);
+        }
+
+        if (null !== $value && !is_scalar($value) && !(\is_object($value) && method_exists($value, '__toString'))) {
+            throw new UnexpectedValueException($value, 'string');
+        }
+
+        $value = (string) $value;
+        if ('' === $value) {
+            return;
+        }
+
+        $zxcvbn = $this->zxcvbnFactory->createZxcvbn();
+
+        $result = $zxcvbn->passwordStrength($value);
+
+        if ($result['score'] < $constraint->minScore) {
+            $this->context->buildViolation($constraint->message)
+                ->setCode(ZxcvbnPasswordStrength::ZXCVBN_PASSWORD_STRENGTH_ERROR)
+                ->setParameter('{{ warning }}', $result['feedback']['warning'] ? "\n".$result['feedback']['warning'] : '')
+                ->setParameter('{{ suggestions }}', $result['feedback']['suggestions'] ? "\n".implode("\n", $result['feedback']['suggestions']) : '')
+                ->addViolation();
+        }
+    }
+}

--- a/tests/Validator/Constraints/ZxcvbnPasswordStrengthTest.php
+++ b/tests/Validator/Constraints/ZxcvbnPasswordStrengthTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Createnl\ZxcvbnBundle\Tests\Validator\Constraints;
+
+use Createnl\ZxcvbnBundle\Validator\Constraints\ZxcvbnPasswordStrength;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Exception\InvalidArgumentException;
+
+final class ZxcvbnPasswordStrengthTest extends TestCase
+{
+    public function testInvalidMinScore(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new ZxcvbnPasswordStrength(null, null, 5);
+    }
+}

--- a/tests/Validator/Constraints/ZxcvbnPasswordStrengthValidatorTest.php
+++ b/tests/Validator/Constraints/ZxcvbnPasswordStrengthValidatorTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Createnl\ZxcvbnBundle\Tests\Validator\Constraints;
+
+use Createnl\ZxcvbnBundle\Validator\Constraints\ZxcvbnPasswordStrength;
+use Createnl\ZxcvbnBundle\Validator\Constraints\ZxcvbnPasswordStrengthValidator;
+use Createnl\ZxcvbnBundle\ZxcvbnFactory;
+use Symfony\Component\Translation\IdentityTranslator;
+use Symfony\Component\Validator\Constraints\IsTrue;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+final class ZxcvbnPasswordStrengthValidatorTest extends ConstraintValidatorTestCase
+{
+    protected function createValidator(): ZxcvbnPasswordStrengthValidator
+    {
+        return new ZxcvbnPasswordStrengthValidator(new ZxcvbnFactory([], new IdentityTranslator()));
+    }
+
+    public function testExpectsConstraintType(): void
+    {
+        $this->expectException(UnexpectedTypeException::class);
+
+        $this->validator->validate('password', new IsTrue());
+    }
+
+    public function testNullIsValid(): void
+    {
+        $this->validator->validate(null, new ZxcvbnPasswordStrength());
+
+        $this->assertNoViolation();
+    }
+
+    public function testEmptyStringIsValid(): void
+    {
+        $this->validator->validate('', new ZxcvbnPasswordStrength());
+
+        $this->assertNoViolation();
+    }
+
+    public function testExpectsStringCompatibleType(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+
+        $this->validator->validate(new \stdClass(), new ZxcvbnPasswordStrength());
+    }
+
+    public function testValidPasswordStrength(): void
+    {
+        $this->validator->validate('db6s[t_%9h;lz7 Gu<pMUr=GO$]N@g9n', new ZxcvbnPasswordStrength());
+
+        $this->assertNoViolation();
+    }
+
+    public function testInvalidPasswordStrength(): void
+    {
+        $this->validator->validate('123456', new ZxcvbnPasswordStrength(null, 'myMessage'));
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ warning }}', "\nThis is a top-10 common password")
+            ->setParameter('{{ suggestions }}', "\nAdd another word or two. Uncommon words are better.")
+            ->setCode(ZxcvbnPasswordStrength::ZXCVBN_PASSWORD_STRENGTH_ERROR)
+            ->assertRaised();
+    }
+}


### PR DESCRIPTION
Hello!
I think it would be nice to have a validator constraint in this bundle too.
The validator is only registered if the user has the `symfony/validator` dependency in their project.